### PR TITLE
Tag @here in release notifications instead of deleted role

### DIFF
--- a/src/lib/discord.ts
+++ b/src/lib/discord.ts
@@ -6,7 +6,6 @@ export async function SendEmbed(
 		url?: string;
 		timestamp?: Date;
 		color?: number;
-		tagId?: string;
 	},
 ) {
 	const embed = {
@@ -16,22 +15,13 @@ export async function SendEmbed(
 		timestamp: data.timestamp,
 		color: data.color,
 	};
-	const body: {
-		embeds: {
-			title?: string;
-			description?: string;
-			url?: string;
-			timestamp?: Date;
-			color?: number;
-		}[];
-		content?: string;
-	} = {
+	const body = {
 		embeds: [embed],
+		content: "@here",
+		// `@here` only pings when "everyone" is in the parse list, even though
+		// the mention text itself is `@here` rather than `@everyone`.
+		allowed_mentions: { parse: ["everyone"] },
 	};
-
-	if (data.tagId) {
-		body.content = `<@&${data.tagId}>`;
-	}
 
 	await fetch(webhookUrl, {
 		method: "POST",

--- a/src/routes/api/webhook/release.ts
+++ b/src/routes/api/webhook/release.ts
@@ -76,7 +76,6 @@ export const ServerRoute = createServerFileRoute(
 				title: "🎁 | New Release",
 				url: "https://github.com/pyclashbot/py-clash-bot/releases/latest",
 				color: 0x03fc49,
-				tagId: "1128136563201671221",
 				...data,
 			});
 		} catch (err) {

--- a/src/routes/api/webhook/release_.prerelease.ts
+++ b/src/routes/api/webhook/release_.prerelease.ts
@@ -76,7 +76,6 @@ export const ServerRoute = createServerFileRoute(
 				title: "📦 | New Pre-Release",
 				url: "https://github.com/pyclashbot/py-clash-bot/releases/latest",
 				color: 0xfca503,
-				tagId: "1128136612715450498",
 				...data,
 			});
 		} catch (err) {


### PR DESCRIPTION
## Problem

The Discord release and prerelease notifications ping a hardcoded role via `tagId` in `SendEmbed`, rendering the content as `<@&ROLE_ID>`. Those role IDs (`1128136563201671221` for release, `1128136612715450498` for prerelease) no longer exist, so the notification shows a broken **"@deleted-role" / missing role** mention.

## Fix

- `src/lib/discord.ts`: replace the `tagId` role mention with a static `@here` ping. Add `allowed_mentions: { parse: ["everyone"] }` — `@here` only fires a notification when `"everyone"` is in the parse list, otherwise the text appears but pings no one.
- `src/routes/api/webhook/release.ts` & `release_.prerelease.ts`: drop the now-unused hardcoded `tagId` role IDs.

## Notes

`pnpm typecheck` and `pnpm check` report pre-existing failures on `master` (the build-time-generated `routeTree.gen` and some lint issues in an untouched `catch` block) — this change introduces no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)