### PR TITLE
feat: add /discord/invite redirect endpoint

### DIFF
--- a/src/lib/umami.ts
+++ b/src/lib/umami.ts
@@ -1,0 +1,64 @@
+const UMAMI_ENDPOINT = "https://analytics.pyclashbot.app/api/send";
+const UMAMI_HOSTNAME = "pyclashbot.app";
+const UMAMI_TIMEOUT_MS = 1000;
+
+interface TrackEventArgs {
+	/** Event name, e.g. "discord-redirect". */
+	name: string;
+	/** Path the event is attributed to, e.g. "/discord/invite". */
+	url: string;
+	/** Arbitrary event data. */
+	data?: Record<string, unknown>;
+	/** The incoming request, used to forward User-Agent and client IP. */
+	request: Request;
+}
+
+/**
+ * Best-effort server-side umami event. Failures and slowness are swallowed so the
+ * caller's response is never blocked or broken. No-op when ANALYTICS_ID is unset.
+ *
+ * Awaited rather than detached: AWS Lambda freezes execution once a response is
+ * returned, so a fire-and-forget promise may never complete. The timeout keeps the
+ * added latency negligible.
+ */
+export async function trackEvent({
+	name,
+	url,
+	data,
+	request,
+}: TrackEventArgs): Promise<void> {
+	const website = process.env.ANALYTICS_ID;
+	if (!website) {
+		return;
+	}
+
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), UMAMI_TIMEOUT_MS);
+
+	try {
+		const headers: Record<string, string> = {
+			"Content-Type": "application/json",
+			// umami rejects requests without a User-Agent.
+			"User-Agent":
+				request.headers.get("user-agent") ?? "pyclashbot-site-server",
+		};
+		const forwardedFor = request.headers.get("x-forwarded-for");
+		if (forwardedFor) {
+			headers["X-Forwarded-For"] = forwardedFor;
+		}
+
+		await fetch(UMAMI_ENDPOINT, {
+			method: "POST",
+			headers,
+			body: JSON.stringify({
+				type: "event",
+				payload: { website, hostname: UMAMI_HOSTNAME, url, name, data },
+			}),
+			signal: controller.signal,
+		});
+	} catch (err) {
+		console.warn("[umami] failed to send event:", err);
+	} finally {
+		clearTimeout(timeout);
+	}
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as ReleasesIndexRouteImport } from './routes/releases/index'
 import { Route as ReleasesLatestRouteImport } from './routes/releases/latest'
 import { Route as ReleasesTagRouteImport } from './routes/releases/$tag'
+import { ServerRoute as DiscordInviteServerRouteImport } from './routes/discord/invite'
 import { ServerRoute as ApiWebhookReleaseServerRouteImport } from './routes/api/webhook/release'
 import { ServerRoute as ApiWebhookReleasePrereleaseServerRouteImport } from './routes/api/webhook/release_.prerelease'
 
@@ -51,6 +52,11 @@ const ReleasesTagRoute = ReleasesTagRouteImport.update({
   id: '/releases/$tag',
   path: '/releases/$tag',
   getParentRoute: () => rootRouteImport,
+} as any)
+const DiscordInviteServerRoute = DiscordInviteServerRouteImport.update({
+  id: '/discord/invite',
+  path: '/discord/invite',
+  getParentRoute: () => rootServerRouteImport,
 } as any)
 const ApiWebhookReleaseServerRoute = ApiWebhookReleaseServerRouteImport.update({
   id: '/api/webhook/release',
@@ -125,27 +131,41 @@ export interface RootRouteChildren {
   ReleasesIndexRoute: typeof ReleasesIndexRoute
 }
 export interface FileServerRoutesByFullPath {
+  '/discord/invite': typeof DiscordInviteServerRoute
   '/api/webhook/release': typeof ApiWebhookReleaseServerRoute
   '/api/webhook/release/prerelease': typeof ApiWebhookReleasePrereleaseServerRoute
 }
 export interface FileServerRoutesByTo {
+  '/discord/invite': typeof DiscordInviteServerRoute
   '/api/webhook/release': typeof ApiWebhookReleaseServerRoute
   '/api/webhook/release/prerelease': typeof ApiWebhookReleasePrereleaseServerRoute
 }
 export interface FileServerRoutesById {
   __root__: typeof rootServerRouteImport
+  '/discord/invite': typeof DiscordInviteServerRoute
   '/api/webhook/release': typeof ApiWebhookReleaseServerRoute
   '/api/webhook/release_/prerelease': typeof ApiWebhookReleasePrereleaseServerRoute
 }
 export interface FileServerRouteTypes {
   fileServerRoutesByFullPath: FileServerRoutesByFullPath
-  fullPaths: '/api/webhook/release' | '/api/webhook/release/prerelease'
+  fullPaths:
+    | '/discord/invite'
+    | '/api/webhook/release'
+    | '/api/webhook/release/prerelease'
   fileServerRoutesByTo: FileServerRoutesByTo
-  to: '/api/webhook/release' | '/api/webhook/release/prerelease'
-  id: '__root__' | '/api/webhook/release' | '/api/webhook/release_/prerelease'
+  to:
+    | '/discord/invite'
+    | '/api/webhook/release'
+    | '/api/webhook/release/prerelease'
+  id:
+    | '__root__'
+    | '/discord/invite'
+    | '/api/webhook/release'
+    | '/api/webhook/release_/prerelease'
   fileServerRoutesById: FileServerRoutesById
 }
 export interface RootServerRouteChildren {
+  DiscordInviteServerRoute: typeof DiscordInviteServerRoute
   ApiWebhookReleaseServerRoute: typeof ApiWebhookReleaseServerRoute
   ApiWebhookReleasePrereleaseServerRoute: typeof ApiWebhookReleasePrereleaseServerRoute
 }
@@ -198,6 +218,13 @@ declare module '@tanstack/react-router' {
 }
 declare module '@tanstack/react-start/server' {
   interface ServerFileRoutesByPath {
+    '/discord/invite': {
+      id: '/discord/invite'
+      path: '/discord/invite'
+      fullPath: '/discord/invite'
+      preLoaderRoute: typeof DiscordInviteServerRouteImport
+      parentRoute: typeof rootServerRouteImport
+    }
     '/api/webhook/release': {
       id: '/api/webhook/release'
       path: '/api/webhook/release'
@@ -227,6 +254,7 @@ export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
 const rootServerRouteChildren: RootServerRouteChildren = {
+  DiscordInviteServerRoute: DiscordInviteServerRoute,
   ApiWebhookReleaseServerRoute: ApiWebhookReleaseServerRoute,
   ApiWebhookReleasePrereleaseServerRoute:
     ApiWebhookReleasePrereleaseServerRoute,

--- a/src/routes/discord/invite.ts
+++ b/src/routes/discord/invite.ts
@@ -1,0 +1,36 @@
+import { createServerFileRoute } from "@tanstack/react-start/server";
+import { trackEvent } from "@/lib/umami";
+
+// Maps a traffic source (?ref=) to a Discord invite. Keeping distinct invite codes
+// per source means Discord's native per-invite analytics also reports the split, on
+// top of umami. To rotate an invite, edit this map — nothing else changes.
+const INVITES = {
+	default: { invite: "https://discord.gg/nqKRkyq2UU", ref: "website" },
+	client: { invite: "https://discord.gg/X7YGaX76EH", ref: "client" },
+} as const;
+
+async function handler({ request }: { request: Request }) {
+	const ref = new URL(request.url).searchParams.get("ref");
+	const target =
+		(ref && INVITES[ref as keyof typeof INVITES]) || INVITES.default;
+
+	await trackEvent({
+		name: "discord-redirect",
+		url: "/discord/invite",
+		data: { ref: target.ref },
+		request,
+	});
+
+	return new Response(null, {
+		status: 302,
+		headers: {
+			Location: target.invite,
+			"Cache-Control": "no-store",
+		},
+	});
+}
+
+export const ServerRoute = createServerFileRoute("/discord/invite").methods({
+	GET: handler,
+	HEAD: handler,
+});


### PR DESCRIPTION
## What

Adds a server-side redirect at `/discord/invite` so public source (py-clash-bot's README and `discord_rpc.py`) can reference our own domain instead of raw `discord.gg/...` invite codes, obfuscating them from scrapers crawling GitHub.

| URL | Destination |
|---|---|
| `/discord/invite` | `discord.gg/nqKRkyq2UU` (website/default) |
| `/discord/invite?ref=client` | `discord.gg/X7YGaX76EH` (py-clash-bot RPC client) |

Unknown/missing `ref` falls back to the default invite.

## How

- **`src/routes/discord/invite.ts`** — `createServerFileRoute` (same pattern as the webhook routes). Returns `302` + `Cache-Control: no-store` so CloudFront/browsers never cache the mapping and invites can be rotated by editing the centralized `INVITES` map. Server routes aren't prerendered and never ship to the client, so the codes stay server-side.
- **`src/lib/umami.ts`** — best-effort `trackEvent()` that POSTs a `discord-redirect` event to the self-hosted umami instance, forwarding User-Agent + `X-Forwarded-For`. Timeout-guarded (1s) and try/caught so analytics never blocks or breaks the redirect; no-ops when `ANALYTICS_ID` is unset. Awaited rather than detached because Lambda freezes after the response returns.

Keeping two distinct invite codes also gives Discord-native per-invite analytics on top of umami.

## Verification

- ✅ `curl` of all three cases (default / `?ref=client` / unknown) returns correct `302` / `Location` / `no-store`
- ✅ `pnpm check` + `pnpm typecheck` clean
- ✅ `pnpm build` succeeds; RPC code `X7YGaX76EH` appears only in the server bundle, never in `public/`

> Note: `nqKRkyq2UU` still appears in the prerendered homepage because it renders py-clash-bot's README content — that resolves once the follow-up repo PR points the README at `/discord/invite`.

## Follow-up (separate, in py-clash-bot repo, after deploy)

- README → `https://pyclashbot.app/discord/invite`
- `pyclashbot/utils/discord_rpc.py` → `https://pyclashbot.app/discord/invite?ref=client`

Design doc: `docs/superpowers/specs/2026-06-04-discord-invite-redirect-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)